### PR TITLE
Version update and DHCP typo fix

### DIFF
--- a/aiotcpwave/dhcp.py
+++ b/aiotcpwave/dhcp.py
@@ -19,14 +19,14 @@ from bidict import bidict
 from .client import TCPWaveClient
 
 
-class TCPWaveDCHP(TCPWaveClient):
+class TCPWaveDHCP(TCPWaveClient):
     """
-    This TCPWave client mixin provides DCHP related features, most importantly
+    This TCPWave client mixin provides DHCP related features, most importantly
     finding active DHCP lease records.
     """
 
     def __init__(self, *vargs, **kwargs):
-        super(TCPWaveDCHP, self).__init__(*vargs, **kwargs)
+        super(TCPWaveDHCP, self).__init__(*vargs, **kwargs)
         self.dhcp_servers = bidict()
 
     async def fetch_dhcp_servers(self, **params):

--- a/examples/ex_dhcp.py
+++ b/examples/ex_dhcp.py
@@ -1,6 +1,6 @@
-from aiotcpwave.dhcp import TCPWaveDCHP
+from aiotcpwave.dhcp import TCPWaveDHCP
 
-api = TCPWaveDCHP()
+api = TCPWaveDHCP()
 
 search_ip = "10.127.20.21"
 search_macaddr = "c4:2a:d0:d6:21:35"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ packages = [
    {include = "aiotcpwave"}
 ]
 license = "Apache-2.0"
-version = "0.0.3"
+version = "0.0.4"
 description = "AsyncIO client for TCPWave"
 authors = ["Jeremy Schulman <jeremy.schulman@mlb.com>"]
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ install_requires = \
 
 setup_kwargs = {
     'name': 'aio-tcpwave',
-    'version': '0.0.2',
+    'version': '0.0.4',
     'description': 'AsyncIO client for TCPWave',
     'long_description': None,
     'author': 'Jeremy Schulman',


### PR DESCRIPTION
In the previous PR the version was not updated in setup.py.
Also renamed DCHP to DHCP.